### PR TITLE
fix: updated symbol issue in the code snippet

### DIFF
--- a/content/00_prerequisites/20_install_and_configs/_index.en.md
+++ b/content/00_prerequisites/20_install_and_configs/_index.en.md
@@ -150,7 +150,7 @@ If [AWS CLI](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-chap-wel
 {{% /notice%}}
 
 ```bash
-aws sts get-caller-identity —profile amplify-handson
+aws sts get-caller-identity --profile amplify-handson
 {
   "UserId": "XXXXXXXXXXXXXXXX",
   "Account": "YYYYYYYYYYYYYYYYY",


### PR DESCRIPTION
# Issue

As you can see, the original dash is not the same with "-", so if you just copy and paste the command, it doesn't work. In addition to this, it should be "--profile" not "-profile"

# Description of changes

Replaced the wrong dash with the right one.